### PR TITLE
remove ascii 160 characters from longitude -84.49983

### DIFF
--- a/globi.json
+++ b/globi.json
@@ -1,4 +1,0 @@
-{ 
-  "_comment": "Sample GloBI dataset descriptor. See http://github.com/globalbioticinteractions for more information.",
-  "citation": "Sarah E Miller. 06/10/2015. Species associations manually extracted from Chamberlin, W. J. The Buprestidae of North America, Exclusive of Mexico, a Catalogue including Synonomy, Bibliography, Distribution, Type Locality and Hosts of Each Species,. 1926."
-}


### PR DESCRIPTION
this weird ascii code ```160``` character that prefixed longitude -84.49983 was causing the parse warning reported in https://travis-ci.org/millerse/Buprestidae-of-North-America . Suggest to merge.